### PR TITLE
Prefixed the CSV file-path by 'Datasets/'

### DIFF
--- a/DecisionTrees_RandomForest_Project_LendingData.ipynb
+++ b/DecisionTrees_RandomForest_Project_LendingData.ipynb
@@ -67,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "df = pd.read_csv('loan_data.csv')"
+    "df = pd.read_csv('Datasets/loan_data.csv')"
    ]
   },
   {


### PR DESCRIPTION
As the data are in a specific directory, namely 'Datasets', that latter must be added as a prefix to all the data file-paths (in all the notebooks, not only this one).
By the way, since Pandas natively reads .bz2 compressed files, you can take that opportunity and compress (with BZip2) all the data files.